### PR TITLE
Sync 1.0.0 progressive history into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,59 @@
 # Catalyst Subcategories Example Lab Project
 
-This is an example developer project demonstrating how to customize a Catalyst codebase. 
+This is an example developer project demonstrating how to customize a Catalyst codebase, building a subcategory listing feature.
 
-## Lab Steps and Commit History
+## Terminology and Git Model
 
-The commit history of the repository is important and represents the steps of the developer labs. Each commit starting with the `start` tag demonstrates the code changes in a lab step.
+This repository maintains two kinds of history **separately**:
+
+- **Traditional branch** (`main`): a normal Git branch with stable, append-only history. Custom-code changes are made on feature branches, reviewed via pull request, and merged here. `main`'s history is never rewritten.
+- **Progressive history**: a tutorial-shaped commit chain (clean framework install → step commits → end metadata) that represents the step-by-step lab progression. It is rebuilt as an independent commit chain and identified by a **project-version tag** (plain semver) at its tip plus the step tags along it.
+
+`main` and the latest progressive history have **different tip commits but identical file trees**. Every change must be replicated across both, using the `bcedu-lab-sync` skill, and verified with its `validate-sync` command:
+
+- **Framework/dependency upgrades**: rebuild a new progressive history with `bcedu-lab-upgrade`, then `sync-to-main` (a reviewed PR) brings it onto `main`.
+- **Custom lab-code changes**: make them on a branch off `main` and merge via PR, then `sync-to-progressive` folds them into a rebuilt progressive history.
+- **Publishing** a progressive history (moving step tags + creating the project-version tip tag) is done with `bcedu-lab-publish`; it does **not** advance `main`.
+
+## Project Version and Changelogs
+
+- The **project version** (plain semver, separate from the Catalyst framework version) is held in `package.json`'s `version` field and tagged on the tip of the corresponding progressive history.
+- Each version has a changelog entry in `CHANGELOG.md`.
+- **Metadata at the end**: the project-version bump and the addition of changelog entries and tutorial docs are folded into the final commit(s) of each rebuilt progressive history (amended on each rebuild rather than accumulating new commits).
+- The lab steps and GitHub diff links live in `docs/TUTORIAL.md`, which carries a "Based on version X" banner matching the latest progressive history.
+
+## Tag Conventions
+
+- **Project-version tag**: plain semver (e.g. `1.0.0`) at a progressive history's tip. Created fresh per history; never migrated.
+- **Framework anchor**: `framework-<semver>` (e.g. `framework-1.6.3`) marks a base-framework release point. Permanent; never migrated.
+- **Step tags**: `<prefix>-NN-pre` / `<prefix>-NN-post`, plus `start` / `complete`. Migrated onto a new history by the Main Tags publish.
+- **eLearning tags**: `e-` prefixed. Migrated by the eLearning publish (none exist yet for this project).
+
+## Commit History Structure
+
+- The first commit is a clean Catalyst install.
+- **Strict 1:1 TODO → code**: each commit that introduces `TODO:` comments is immediately followed by the code commit that resolves them (one TODO commit per code commit). Avoid bundling many TODOs into a single early commit.
 
 ### Lab Exercises
 
 | Exercise | Description | Tag Prefix |
 | ------ | ----------- | ---------- |
 | Main Lab | Add Subcategory Listing | `lab` |
+
+### Lab Step Breakdown
+
+Each step is a `<tag>-pre` (TODO placeholders) commit immediately followed by a `<tag>-post` (implementation) commit.
+
+**Main Lab — Add Subcategory Listing (`lab`)** — start: `start`, complete: `complete`
+
+| Step | Tag Base | Description |
+| ---- | --- | ----------- |
+| 1 | `lab-01` | Add subcategories GraphQL query |
+| 2a | `lab-02a` | Add component shell for subcategory list |
+| 2b | `lab-02b` | Add main subcategory list content |
+| 2c | `lab-02c` | Add content for each subcategory |
+| 3a | `lab-03a` | Customize card component variables for subcategory list |
+| 3b | `lab-03b` | Finish application of theme styles for subcategory list |
 
 ## File Removal - Protected Paths
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 1.0.0
+
+_Based on Catalyst (`@bigcommerce/catalyst-makeswift`) 1.6.3_
+
+### Summary
+
+First project-versioned progressive history. Establishes the project's own version line (separate from the base-framework version) and the supporting structure: a dedicated tutorial document, a root changelog, and the traditional-branch / progressive-history Git model.
+
+### Changes
+
+- Adopt the progressive-history structure: `main` becomes a stable, append-only traditional branch, while the tutorial-shaped progressive history is rebuilt as an independent commit chain identified by the `1.0.0` project-version tag.
+- Set the project version (`package.json` `version`) to `1.0.0`, independent of the base-framework version.
+- Re-tag legacy base-framework version tags with the `framework-` prefix to reserve plain semver for project versions.
+- Move the lab step listing and diff links out of `README.md` into `docs/TUTORIAL.md` (with a "Based on version 1.0.0" banner); `README.md` now links to it.
+- Expand `AGENTS.md` (and its `CLAUDE.md` symlink) with the terminology, Git model, version/changelog conventions, tag taxonomy, the strict 1:1 TODO → code rule, and the per-step breakdown.

--- a/README.md
+++ b/README.md
@@ -14,23 +14,6 @@ To observe the effects of this feature, your BigCommerce store should have at le
 
 See [Catalyst setup documentation](https://www.catalyst.dev/docs/workflows/one-click-catalyst).
 
-## Lab Steps
+## Lab Exercises
 
-* [Step 1: Add GraphQL for subcategories](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-01-pre...lab-01-post?diff=split)
-* Step 2: Add subcategory list component
-  * [Step 2a: Add component shell for subcategory list](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-02a-pre...lab-02a-post?diff=split)
-  * [Step 2b: Add main subcategory list content](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-02b-pre...lab-02b-post?diff=split)
-  * [Step 2c: Add content for each subcategory](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-02c-pre...lab-02c-post?diff=split)
-* Step 3: Subcategory list theme customization
-  * [Step 3a: Customize Soul card variables](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-03a-pre...lab-03a-post?diff=split)
-  * [Step 3b: Finish theme styles for subcategory list](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-03b-pre...lab-03b-post?diff=split)
-
-[Full Lab Diff](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/start...complete?diff=split)
-
-## Finished State
-
-Set up with all features complete:
-
-```shell
-git clone git@github.com:bigcommerce-edu/lab-catalyst-subcategories.git
-```
+The lab exercises and their step-by-step diffs are documented in [docs/TUTORIAL.md](docs/TUTORIAL.md).

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,0 +1,36 @@
+# Lab Tutorial: Catalyst Subcategory Listing
+
+> **Based on version 1.0.0** — this tutorial corresponds to the latest progressive history tagged `1.0.0`.
+
+This document lists the lab exercises and their step-by-step diffs. Each step links to a GitHub comparison between the step's `*-pre` (TODO placeholders) and `*-post` (implemented) tags.
+
+## Main Lab: Add Subcategory Listing
+
+### Getting Started
+
+Copy the _start_ branch.
+
+```shell
+git clone git@github.com:bigcommerce-edu/lab-catalyst-subcategories.git
+```
+
+### Lab Steps
+
+* [Step 1: Add GraphQL for subcategories](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-01-pre...lab-01-post?diff=split)
+* Step 2: Add subcategory list component
+  * [Step 2a: Add component shell for subcategory list](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-02a-pre...lab-02a-post?diff=split)
+  * [Step 2b: Add main subcategory list content](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-02b-pre...lab-02b-post?diff=split)
+  * [Step 2c: Add content for each subcategory](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-02c-pre...lab-02c-post?diff=split)
+* Step 3: Subcategory list theme customization
+  * [Step 3a: Customize card component variables](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-03a-pre...lab-03a-post?diff=split)
+  * [Step 3b: Finish theme styles for subcategory list](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/lab-03b-pre...lab-03b-post?diff=split)
+
+[Full Lab Diff](https://github.com/bigcommerce-edu/lab-catalyst-subcategories/compare/start...complete?diff=split)
+
+### Finished State
+
+Set up with all features complete:
+
+```shell
+git clone git@github.com:bigcommerce-edu/lab-catalyst-subcategories.git
+```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nextjs"
   ],
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "scripts": {


### PR DESCRIPTION
Syncs the metadata of the newly published `1.0.0` progressive history onto the traditional branch (`main`).

## What this does
Brings `main` to the **same file tree** as the `1.0.0` progressive history. The two have different commit SHAs (independent histories) but identical trees, per the progressive-history Git model.

## Changes
- Bump project version (`package.json` `version`) `0.1.0` → `1.0.0`
- Add `CHANGELOG.md` with the `1.0.0` entry (based on Catalyst `@bigcommerce/catalyst-makeswift` 1.6.3)
- Add `docs/TUTORIAL.md` (lab steps + diff links, "Based on version 1.0.0" banner); move that content out of `README.md`, which now links to it
- Expand `AGENTS.md` (and its `CLAUDE.md` symlink): terminology, traditional-branch vs progressive-history Git model, version/changelog conventions, tag taxonomy, the strict 1:1 TODO→code rule, and the per-step breakdown

## Verification
`git diff --stat rebuild/1.0.0 sync/1.0.0-to-main` is empty — trees are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
