### PR TITLE
Sync 1.0.1 progressive history into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.1
+
+_Based on Catalyst (`@bigcommerce/catalyst-makeswift`) 1.6.3_
+
+### Summary
+
+Restructured history to move TODO comments immediately before the code that resolves them.
+
 ## 1.0.0
 
 _Based on Catalyst (`@bigcommerce/catalyst-makeswift`) 1.6.3_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-AGENTS.md
+# CLAUDE.md
+
+@AGENTS.md

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,6 +1,6 @@
 # Lab Tutorial: Catalyst Subcategory Listing
 
-> **Based on version 1.0.0** — this tutorial corresponds to the latest progressive history tagged `1.0.0`.
+> **Based on version 1.0.1** — this tutorial corresponds to the latest progressive history tagged `1.0.1`.
 
 This document lists the lab exercises and their step-by-step diffs. Each step links to a GitHub comparison between the step's `*-pre` (TODO placeholders) and `*-post` (implemented) tags.
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nextjs"
   ],
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "scripts": {


### PR DESCRIPTION
Syncs the metadata of the `1.0.1` progressive history onto `main`, keeping the traditional branch in sync with the latest published history.

`1.0.1` restructured the progressive history so each `TODO:` commit immediately precedes the code commit that resolves it (strict 1:1 TODO→code), eliminating the bundled "Initial lab TODOs" commit. The lab code's final state is unchanged from `1.0.0`, so this sync is **metadata-only**.

## Changes
- `CHANGELOG.md` — add the `1.0.1` entry
- `package.json` — version `1.0.0` → `1.0.1`
- `docs/TUTORIAL.md` — banner `1.0.0` → `1.0.1`
- `CLAUDE.md` — symlink → regular file with `@AGENTS.md` import

## Verification
`git diff 1.0.1 <this branch>` is empty — the tree is identical to the `1.0.1` progressive-history tip (independent histories, same file content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
